### PR TITLE
Music app (native) is crashing while trying to launch it.

### DIFF
--- a/packages/apps/Music/src/com/android/music/MediaPlaybackService.java
+++ b/packages/apps/Music/src/com/android/music/MediaPlaybackService.java
@@ -335,7 +335,7 @@ public class MediaPlaybackService extends Service {
                 | RemoteControlClient.FLAG_KEY_MEDIA_STOP;
         mRemoteControlClient.setTransportControlFlags(flags);
         
-        mPreferences = getSharedPreferences("Music", MODE_WORLD_READABLE | MODE_WORLD_WRITEABLE);
+        mPreferences = getSharedPreferences("Music", MODE_PRIVATE);
         mCardId = MusicUtils.getCardId(this);
         
         registerExternalStorageListener();

--- a/packages/apps/Music/src/com/android/music/TouchInterceptor.java
+++ b/packages/apps/Music/src/com/android/music/TouchInterceptor.java
@@ -77,7 +77,7 @@ public class TouchInterceptor extends ListView {
 
     public TouchInterceptor(Context context, AttributeSet attrs) {
         super(context, attrs);
-        SharedPreferences pref = context.getSharedPreferences("Music", 3);
+        SharedPreferences pref = context.getSharedPreferences("Music", 0);
         mRemoveMode = pref.getInt("deletemode", -1);
         mTouchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
         Resources res = getResources();


### PR DESCRIPTION
Root-Cause : Security Exception due to use of a deprecated API.

Fix : Using the correct supported API. Back Ported this change from Oreo