### PR TITLE
Audio is not getting routed to wireless BT speaker even after successful pairing

### DIFF
--- a/device/brcm/rpi3/audio_policy_configuration.xml
+++ b/device/brcm/rpi3/audio_policy_configuration.xml
@@ -23,6 +23,7 @@
         </module>
 
         <xi:include href="usb_audio_policy_configuration.xml"/>
+        <xi:include href="a2dp_audio_policy_configuration.xml"/>
     </modules>
 
     <xi:include href="audio_policy_volumes.xml"/>

--- a/device/brcm/rpi3/rpi3.mk
+++ b/device/brcm/rpi3/rpi3.mk
@@ -22,6 +22,7 @@ PRODUCT_PACKAGES += \
     gralloc.$(TARGET_PRODUCT) \
     hwcomposer.$(TARGET_PRODUCT) \
     audio.primary.$(TARGET_PRODUCT) \
+    audio.a2dp.default \
     audio.usb.default \
     wpa_supplicant \
     wpa_supplicant.conf
@@ -54,6 +55,7 @@ PRODUCT_COPY_FILES := \
     frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:system/etc/media_codecs_google_audio.xml \
     frameworks/av/media/libstagefright/data/media_codecs_google_telephony.xml:system/etc/media_codecs_google_telephony.xml \
     frameworks/av/media/libstagefright/data/media_codecs_google_video.xml:system/etc/media_codecs_google_video.xml \
+    frameworks/av/services/audiopolicy/config/a2dp_audio_policy_configuration.xml:system/etc/a2dp_audio_policy_configuration.xml \
     frameworks/av/services/audiopolicy/config/usb_audio_policy_configuration.xml:system/etc/usb_audio_policy_configuration.xml \
     frameworks/av/services/audiopolicy/config/default_volume_tables.xml:system/etc/default_volume_tables.xml \
     frameworks/av/services/audiopolicy/config/audio_policy_volumes.xml:system/etc/audio_policy_volumes.xml \


### PR DESCRIPTION
Root-Cause : The A2DP HAL Library is not getting loaded.

Fix : Configured the RPI 3 make file to include A2DP HAL Library.