### PR TITLE
There is no home screen or native apps like Music, Gallery etc. in the app browser.

### DIFF
--- a/device/brcm/rpi3/rpi3.mk
+++ b/device/brcm/rpi3/rpi3.mk
@@ -11,10 +11,27 @@ include frameworks/native/build/tablet-7in-hdpi-1024-dalvik-heap.mk
 
 # application packages
 PRODUCT_PACKAGES += \
-    Launcher2 \
-    LeanbackLauncher \
     Settings \
-    Browser2
+    Launcher3 \
+    ManagedProvisioning \
+    Bluetooth \
+    Gallery \
+    SpeechRecorder \
+    Browser2 \
+    Gallery2 \
+    Music \
+    Calculator \
+    DeskClock \
+    MusicFX \
+    StorageManager \
+    Calendar \
+    DevCamera \
+    Camera2 \
+    Terminal \
+    PackageInstaller \
+    Settings \
+    Phone \
+    SoundRecorder
 
 # system packages
 PRODUCT_PACKAGES += \


### PR DESCRIPTION

Root-Cause : There is no default Launcher application and native applications in make-file configuration.
Fix : Make sure that applications are launch after device boot up. Adding applications in PRODUCT_PACKAGES.